### PR TITLE
Remove listener for checkout order save event

### DIFF
--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -36,10 +36,6 @@ class EventServiceProvider extends ServiceProvider
             'Webkul\Varnish\Listeners\Review@beforeDelete',
         ],
 
-        'checkout.order.save.after'     => [
-            'Webkul\Varnish\Listeners\Order@afterCancelOrCreate',
-        ],
-
         'sales.order.cancel.after'      => [
             'Webkul\Varnish\Listeners\Order@afterCancelOrCreate',
         ],


### PR DESCRIPTION
Removed event listener for 'checkout.order.save.after'.